### PR TITLE
Unignore Day 05, Part 2 test

### DIFF
--- a/src/bin/day_05_part_1.rs
+++ b/src/bin/day_05_part_1.rs
@@ -155,7 +155,7 @@ fn main() -> anyhow::Result<()> {
 }
 
 #[cfg(test)]
-mod day_04_part_1_tests {
+mod day_05_part_1_tests {
     use super::*;
 
     #[test]

--- a/src/bin/day_05_part_2.rs
+++ b/src/bin/day_05_part_2.rs
@@ -367,7 +367,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 }
 
 #[cfg(test)]
-mod day_04_part_1_tests {
+mod day_05_part_2_tests {
     use super::*;
 
     #[test]
@@ -379,7 +379,6 @@ mod day_04_part_1_tests {
     }
 
     #[test]
-    #[ignore = "This test takes several minutes to run"]
     fn check_full_input() {
         let input = include_str!("../inputs/day_05.txt");
         let almanac = Almanac::from_str(input).unwrap();


### PR DESCRIPTION
This removes an `#[ignore]` on the Day 05, Part 2 full input test. That took forever when we had the slow version of the program, but now that we have the sub-millisecond implementation we should include this test.

I also had the wrong module names on the Day 05 tests due to copy-paste problems, and this fixes that.